### PR TITLE
Upgrade to tools barebone 1.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,14 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Install system dependencies
-        # remove occasionally problematic repositories we don't use anyway
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt update
-          sudo apt install chromium-browser chromium-chromedriver
+      - uses: nanasess/setup-chromedriver@master
+        #with:
+          # Optional: do not specify to match Chrome's version
+          #chromedriver-version: '88.0.4324.96'
+      - run: |
+          export DISPLAY=:99
+          chromedriver --url-base=/wd/hub &
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
 
       - name: Set up Python 3.6
         uses: actions/setup-python@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM materialscloud/tools-barebone:1.1.0
+FROM materialscloud/tools-barebone:1.1.2
 
 LABEL maintainer="Giovanni Pizzi <giovanni.pizzi@epfl.ch>"
 

--- a/barebone-requirements.txt
+++ b/barebone-requirements.txt
@@ -1,1 +1,1 @@
-tools_barebone==1.1.2
+tools-barebone==1.1.2

--- a/barebone-requirements.txt
+++ b/barebone-requirements.txt
@@ -1,1 +1,1 @@
-tools_barebone==1.0.0
+tools_barebone==1.1.2

--- a/compute/seekpath_web_module.py
+++ b/compute/seekpath_web_module.py
@@ -17,7 +17,7 @@ from tools_barebone import logme, get_tools_barebone_version
 from tools_barebone.structure_importers import get_structure_tuple, UnknownFormatError
 
 # Version of tools-seekpath
-__version__ = "20.11.0"
+__version__ = "21.05.0"
 
 
 class FlaskRedirectException(Exception):

--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,13 @@ additional_accordion_entries:
     template_page: definitions.html
 
 about_section_title: "What SeeK-path does"
+
+upload_structure_block_order:
+  - qeinp-qetools
+  - cif-ase
+  - cif-pymatgen
+  - xyz-ase
+  - xsf-ase
+  - vasp-ase
+  - castep-ase
+  - pdb-ase

--- a/user_static/minify.sh
+++ b/user_static/minify.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## To install:
 ## npm install clean-css-cli -g
-## npm install uglifyjs -g
+## npm install uglify-js -g
 
 
 for cssfile in css/orig/*.css


### PR DESCRIPTION
Use `tools-barebone` v1.1.2, which was released to upgrade the parser `ase` to v3.21.1, fixing a bug for parsing cif files.
Moreover, the input file formats in the dropdown menu were reordered.