### PR TITLE
Use the npm package for the BZVisualizer.js

### DIFF
--- a/admin-tools/build-docker.sh
+++ b/admin-tools/build-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ../user_static
+cd user_static
 ./minify.sh
 cd ..
 

--- a/admin-tools/build-docker.sh
+++ b/admin-tools/build-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd user_static
+cd ../user_static
 ./minify.sh
 cd ..
 

--- a/user_static/minify.sh
+++ b/user_static/minify.sh
@@ -3,6 +3,8 @@
 ## npm install clean-css-cli -g
 ## npm install uglify-js -g
 
+npm install brillouinzone-visualizer
+cp node_modules/brillouinzone-visualizer/es6/BZVisualizer.js js/orig/BZVisualizer.js
 
 for cssfile in css/orig/*.css
 do


### PR DESCRIPTION
We are going to use the npm package "brillouinzone-visualizer" for the BZVisualizer.js file.