### PR TITLE
Upgrade to tools-barebone 1.2.0

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,58 @@
+name: Push image to Docker Hub
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-docker-image:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    outputs:
+      version: ${{ steps.setup.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set image tag
+        id: setup
+        run: echo "::set-output name=version::${GITHUB_REF#refs/tags/v}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: |
+            materialscloud/${{ github.event.repository.name }}:latest
+            materialscloud/${{ github.event.repository.name }}:${{ steps.setup.outputs.version }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM materialscloud/tools-barebone:1.1.3
+FROM materialscloud/tools-barebone:1.2.0
 
 LABEL maintainer="Giovanni Pizzi <giovanni.pizzi@epfl.ch>"
 

--- a/barebone-requirements.txt
+++ b/barebone-requirements.txt
@@ -1,1 +1,1 @@
-tools-barebone==1.1.3
+tools-barebone==1.2.0

--- a/compute/seekpath_web_module.py
+++ b/compute/seekpath_web_module.py
@@ -17,7 +17,7 @@ from tools_barebone import logme, get_tools_barebone_version
 from tools_barebone.structure_importers import get_structure_tuple, UnknownFormatError
 
 # Version of tools-seekpath
-__version__ = "21.06.0"
+__version__ = "21.10.0"
 
 
 class FlaskRedirectException(Exception):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 seekpath==2.0.1
 # The following is needed to get the Brillouin zone
-scipy==1.4.1
+scipy==1.5.4


### PR DESCRIPTION
* Uses most recent base image tools-barebone 1.2.0, based on Ubuntu 20.04. 
The new tools-barebone is also updated to keep only 2 weeks of logs (see the corresponding [PR](https://github.com/materialscloud-org/tools-barebone/pull/30) on tools-barebone).

* Adds a github action to build and upload the image to Docker Hub when a new tag is pushed.