### PR TITLE
Updated to barebonesV1.3 (stable), added CDN delivered header …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM materialscloud/tools-barebone:1.2.0
+FROM materialscloud/tools-barebone:1.3.0
 
 LABEL maintainer="Giovanni Pizzi <giovanni.pizzi@epfl.ch>"
 

--- a/barebone-requirements.txt
+++ b/barebone-requirements.txt
@@ -1,1 +1,1 @@
-tools-barebone==1.2.0
+tools-barebone==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-seekpath==2.0.1
+seekpath==2.1.0
 # The following is needed to get the Brillouin zone
 scipy==1.5.4

--- a/user_templates/visualizer_base.html
+++ b/user_templates/visualizer_base.html
@@ -654,6 +654,6 @@
     { name: "SeeK-path: the k-path finder and visualizer", link: "https://www.materialscloud.org/work/tools/seekpath" }
   ];
 </script>
-<script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@v0.1.0/header.js" defer></script>
+<script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@v0.1.1/header.js" defer></script>
 </body>
 </html>

--- a/user_templates/visualizer_base.html
+++ b/user_templates/visualizer_base.html
@@ -654,6 +654,6 @@
     { name: "SeeK-path: the k-path finder and visualizer", link: "https://www.materialscloud.org/work/tools/seekpath" }
   ];
 </script>
-<script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@v0.1.1/header.js" defer></script>
+<script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@v0.1.2/header.js" defer></script>
 </body>
 </html>

--- a/user_templates/visualizer_base.html
+++ b/user_templates/visualizer_base.html
@@ -81,7 +81,6 @@
 
 </head>
 <body onresize='resize_canvases()'>
-
     <div id="above">
 
       <div id="maintitle">
@@ -648,5 +647,13 @@
     </div>
 
 <div style ="position: relative" data-iframe-height></div>
+<script>
+  var breadcrumbsPath = [
+    { name: "Work", link: "https://www.materialscloud.org/work/menu" },
+    { name: "Tools", link: "https://www.materialscloud.org/work/tools/options"},
+    { name: "SeeK-path: the k-path finder and visualizer", link: "https://www.materialscloud.org/work/tools/seekpath" }
+  ];
+</script>
+<script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@v0.1.0/header.js" defer></script>
 </body>
 </html>

--- a/user_templates/visualizer_base.html
+++ b/user_templates/visualizer_base.html
@@ -649,11 +649,11 @@
 <div style ="position: relative" data-iframe-height></div>
 <script>
   var breadcrumbsPath = [
-    { name: "Work", link: "https://www.materialscloud.org/work/menu" },
-    { name: "Tools", link: "https://www.materialscloud.org/work/tools/options"},
+    { name: "Work", link: "https://www.materialscloud.org/work" },
+    { name: "Tools", link: "https://www.materialscloud.org/work/tools"},
     { name: "SeeK-path: the k-path finder and visualizer", link: "https://www.materialscloud.org/work/tools/seekpath" }
   ];
 </script>
-<script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@v0.1.2/header.js" defer></script>
+<script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@main/header.js" defer></script>
 </body>
 </html>

--- a/user_views/bravaissymbol_explanation.html
+++ b/user_views/bravaissymbol_explanation.html
@@ -83,14 +83,14 @@
         
         <script>
             var breadcrumbsPath = [
-              { name: "Work", link: "https://www.materialscloud.org/work/menu" },
-              { name: "Tools", link: "https://www.materialscloud.org/work/tools/options"},
+              { name: "Work", link: "https://www.materialscloud.org/work" },
+              { name: "Tools", link: "https://www.materialscloud.org/work/tools"},
               { name: "SeeK-path: the k-path finder and visualizer", link: "https://www.materialscloud.org/work/tools/seekpath" },
               { name: "Bravais lattice details", link: null }
     
             ];
           </script>
-          <script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@v0.1.2/header.js" defer></script>
+          <script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@main/header.js" defer></script>
 </body>
 
 </html>

--- a/user_views/bravaissymbol_explanation.html
+++ b/user_views/bravaissymbol_explanation.html
@@ -80,7 +80,17 @@
 
         </div>
         <div style="position: relative" data-iframe-height></div>
-
+        
+        <script>
+            var breadcrumbsPath = [
+              { name: "Work", link: "https://www.materialscloud.org/work/menu" },
+              { name: "Tools", link: "https://www.materialscloud.org/work/tools/options"},
+              { name: "SeeK-path: the k-path finder and visualizer", link: "https://www.materialscloud.org/work/tools/seekpath" },
+              { name: "Bravais lattice details", link: null }
+    
+            ];
+          </script>
+          <script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@v0.1.2/header.js" defer></script>
 </body>
 
 </html>

--- a/user_views/termsofuse.html
+++ b/user_views/termsofuse.html
@@ -56,7 +56,7 @@
 
     <script>
         var breadcrumbsPath = [
-          { name: "Work", link: "https://www.materialscloud.org/work/menu" },
+          { name: "Work", link: "https://www.materialscloud.org/work" },
           { name: "Tools", link: "https://www.materialscloud.org/work/tools"},
           { name: "SeeK-path: the k-path finder and visualizer", link: "https://www.materialscloud.org/work/tools/seekpath" },
           { name: "Terms of Use", link: null }

--- a/user_views/termsofuse.html
+++ b/user_views/termsofuse.html
@@ -57,13 +57,13 @@
     <script>
         var breadcrumbsPath = [
           { name: "Work", link: "https://www.materialscloud.org/work/menu" },
-          { name: "Tools", link: "https://www.materialscloud.org/work/tools/options"},
+          { name: "Tools", link: "https://www.materialscloud.org/work/tools"},
           { name: "SeeK-path: the k-path finder and visualizer", link: "https://www.materialscloud.org/work/tools/seekpath" },
           { name: "Terms of Use", link: null }
 
         ];
       </script>
-      <script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@v0.1.2/header.js" defer></script>
+      <script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@main/header.js" defer></script>
 </body>
 
 </html>

--- a/user_views/termsofuse.html
+++ b/user_views/termsofuse.html
@@ -53,6 +53,17 @@
         <p>If you have any questions about these Terms, please contact us. </p>
     </div>
     <div style="position: relative" data-iframe-height></div>
+
+    <script>
+        var breadcrumbsPath = [
+          { name: "Work", link: "https://www.materialscloud.org/work/menu" },
+          { name: "Tools", link: "https://www.materialscloud.org/work/tools/options"},
+          { name: "SeeK-path: the k-path finder and visualizer", link: "https://www.materialscloud.org/work/tools/seekpath" },
+          { name: "Terms of Use", link: null }
+
+        ];
+      </script>
+      <script src="https://cdn.jsdelivr.net/gh/materialscloud-org/mc-header@v0.1.2/header.js" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
I believe this tool is live on:
https://tools.materialscloud.org/seekpath/
which has no header implemented and is rendered as an iFrame on:
https://www.materialscloud.org/work/tools/seekpath

I have updated it for the migration (the best i easily can) and it builds successfully...
There is a Docker compatibility issue between barebones v1.4 and this tool.
a numpy update means this tool is stuck on py3.7, while bb v1.4 uses py3.10...

So for now;
1. Updated to use the barebones v1.3 (which fetches the header on tools landing page)
2. Add breadcrumbing to this tool. 
3. Get the header through CDN injection [see]: (github.com/materialscloud-org/mc-header)

If I get time after the migration; 
1. I'll look to see if we can migrate this codebase to a newer py release within MC.
2. See if there is a nicer way to build tools without relying on this clunky barebones.
3. Look at migrating '_all_' of the site to use mc-header (after addition of @media tracking) so that it says in cache and is not rebuilt/differ from page to page.